### PR TITLE
Fix5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
+        <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.version>2.3.6</jaxb.version>
         <activation.version>1.2.2</activation.version>
         <junit.jupiter.version>5.9.0</junit.jupiter.version>
@@ -41,9 +42,15 @@
 
     <dependencies>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>${jaxb.api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>${jaxb.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <!-- JAXB needs javax.activation module (jdk9) -->
         <dependency>
@@ -119,19 +126,6 @@
                     <generatePackage>com.automation.xmldoclet.xjc</generatePackage>
                     <schemaDirectory>src/main/xjc</schemaDirectory>
                     <strict>false</strict>
-                </configuration>
-            </plugin>
-            <plugin>
-                <!-- Set java version target, use project source encoding -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <release>${java.version}</release>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <optimize>true</optimize>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,9 @@
                     <extension>true</extension>
                     <generatePackage>com.automation.xmldoclet.xjc</generatePackage>
                     <schemaDirectory>src/main/xjc</schemaDirectory>
+                    <bindingIncludes>
+                            <include>**/*.xb</include>
+                    </bindingIncludes>
                     <strict>false</strict>
                 </configuration>
             </plugin>

--- a/src/main/java/com/automation/xmldoclet/ClassList.java
+++ b/src/main/java/com/automation/xmldoclet/ClassList.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2023 CloudBlue.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.automation.xmldoclet;
+
+import com.automation.xmldoclet.xjc.Class;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+/**
+ *
+ * @author sparry
+ * @param <C>
+ */
+public class ClassList<C extends Class> extends ArrayList<C> {
+    protected HashMap<String, Class> map;
+
+    @Override
+    public boolean contains(Object o) {
+        return map.containsKey(((Class)o).getQualified());
+    }
+
+    @Override
+    public boolean add(C c) {
+        if (!map.containsKey(c.getQualified())) {
+            map.put(c.getQualified(), c);
+            return super.add(c);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if (map.remove(((Class)o).getQualified(), o)) {
+            return super.remove(o);
+        } else {
+            return false;
+        }
+    }
+    
+    @Override
+    public void replaceAll(UnaryOperator<C> operator) {
+        map.clear();
+        super.replaceAll(operator);
+        this.stream().forEach(c -> map.put(c.getQualified(), c));
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super C> filter) {
+        this.stream().filter(filter).forEach(c -> map.remove(c.getQualified()));
+        return super.removeIf(filter);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> coll) {
+        if (super.retainAll(coll) ) {
+            map.clear();
+            this.stream().forEach(c -> map.put(c.getQualified(), c));
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> coll) {
+        if (super.removeAll(coll) ) {
+            coll.stream().forEach(o -> map.remove(((Class)o).getQualified()));
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    protected void removeRange(int fromIndex, int toIndex) {
+        this.subList(fromIndex, toIndex).stream().forEach(c -> map.remove(c.getQualified()));
+        super.removeRange(fromIndex, toIndex);
+    }
+
+    @Override
+    public boolean addAll(int index, Collection<? extends C> coll) {
+        int i = 0;
+        boolean retVal = false;
+        for(C c: coll) {
+            if (!map.containsKey(c.getQualified())) {
+                map.put(c.getQualified(), c);
+                retVal = retVal || true;
+                add(i++, c);
+            }
+        }
+        return retVal;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends C> coll) {
+        return coll.stream().mapToLong(o -> add((C)o) ? 1 : 0).sum() > 0;
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+        super.clear();
+    }
+
+    @Override
+    public C remove(int index) {
+        if (index < super.size() && index >=0) {
+            String key = super.get(index).getQualified();
+            map.remove(key);
+            return super.remove(index);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void add(int index, C c) {
+        if (!map.containsKey(c.getQualified())) {
+            map.put(c.getQualified(), c);
+            super.add(index, c);
+        }
+    }
+
+    @Override
+    public C set(int index, C c) {
+        if (index < super.size() && index >=0 && c != null) {
+            String key = super.get(index).getQualified();
+            if (! c.getQualified().equals(key)) {
+                if(map.containsKey(c.getQualified())) {
+                    return null;
+                } else {
+                    map.remove(key);
+                    map.put(c.getQualified(), c);
+                    return super.set(index, c);
+                }
+            } else {
+                return super.set(index, c);
+            }
+        } else {
+            return null;
+        }
+    }
+
+    public ClassList(int initialCapacity) {
+        super(initialCapacity);
+        map = new HashMap<>(initialCapacity);
+    }
+
+    public ClassList() {
+        super();
+        map = new HashMap<>();
+    }
+
+    public ClassList(Collection<? extends C> coll) {
+        super(coll);
+        coll.stream().forEach(c -> map.put(c.getQualified(), c));
+    }
+    
+}

--- a/src/main/java/com/automation/xmldoclet/Parser.java
+++ b/src/main/java/com/automation/xmldoclet/Parser.java
@@ -170,7 +170,15 @@ public class Parser {
                 xmlClass.getMethod().add(transformMethodElement(methodElement));
             }
         }
+
         getXmlPackage(typeElement).getClazz().add(xmlClass);
+
+        for (Element enclosedElement : typeElement.getEnclosedElements()) {
+            if (enclosedElement.getKind().isClass() || enclosedElement.getKind().isInterface() ) {
+                final TypeElement enclosedTypeElement = (TypeElement) enclosedElement;
+                transformTypeElement(enclosedTypeElement);
+            }
+        }
     }
 
     private void transformInterfaceType(TypeElement typeElement) {
@@ -193,6 +201,11 @@ public class Parser {
             if (enclosedElement.getKind() == ElementKind.METHOD) {
                 final ExecutableElement methodElement = (ExecutableElement) enclosedElement;
                 xmlInterface.getMethod().add(transformMethodElement(methodElement));
+            } else if (enclosedElement.getKind() == ElementKind.CLASS ||
+                    enclosedElement.getKind() == ElementKind.ANNOTATION_TYPE ||
+                    enclosedElement.getKind() == ElementKind.INTERFACE ) {
+                final TypeElement enclosedTypeElement = (TypeElement) enclosedElement;
+                transformTypeElement(enclosedTypeElement);
             }
         }
         getXmlPackage(typeElement).getInterface().add(xmlInterface);

--- a/src/main/xjc/javadoc.xb
+++ b/src/main/xjc/javadoc.xb
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2023 CloudBlue.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<jxb:bindings 
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
+    xs:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+    version="2.1">
+
+    <jxb:bindings schemaLocation="javadoc.xsd">
+        <jxb:bindings node="//xs:complexType[@name='package']/xs:sequence/xs:element[@name='class']">
+            <jxb:property collectionType="com.automation.xmldoclet.ClassList"  />
+        </jxb:bindings>
+    </jxb:bindings>
+
+</jxb:bindings>
+


### PR DESCRIPTION
I have created a possible fix for Issue #5
It turns out the problem is not caused by the XML doclet, but by inconsistent processing by JavaDoc itself. If you give JD an explicit file to work with, it parses and processes the inner classes at the top level, and then again as contained elements of the outer class. If you give it a package, it only processes the inner classes as contained elements. Hence, if you add class processing to the outer class parsing, it generates two copies in some cases. To solve this, I am maintaining a keyed list of classes, within each package, by qualified name. This list refuses duplicates.